### PR TITLE
POD syntax fixes

### DIFF
--- a/lib/Git/Code/Review/Tutorial.pm
+++ b/lib/Git/Code/Review/Tutorial.pm
@@ -124,6 +124,8 @@ Pick defaults to using a randomized ordering for returning commits.  This is int
 reviewing code at the same time.  Not wanting to lock you into our madness, you can re-order the pick using the order which has
 3 options:
 
+=over
+
 =item  B<asc> - By date ascending
 
 =item  B<desc> - By date descending
@@ -133,6 +135,8 @@ reviewing code at the same time.  Not wanting to lock you into our madness, you 
 To specify you'd like the earliest available commit, use:
 
     $ git-code-review pick --order asc
+
+=back
 
 =head3 Approval
 


### PR DESCRIPTION
This should allow to regenerate Tutorial.mkdn without the disgracious
section "POD ERRORS" at the end.
