### PR TITLE
Write back the configuration we just read into the %CFG hash

### DIFF
--- a/lib/Git/Code/Review/Utilities.pm
+++ b/lib/Git/Code/Review/Utilities.pm
@@ -187,6 +187,8 @@ sub gcr_config {
             next unless @configs;
             $_config{$sub} = @configs > 1 ? $merge->merge(@configs) : $configs[0];
         }
+
+        %CFG = %_config;
     }
     return wantarray ? %_config : { %_config };
 }


### PR DESCRIPTION
This was not done, so in this module only the configuration value
of 'editor' was ever set. Notably, the 'user' configuration setting
was ignored.
