### PR TITLE
Some template nits

### DIFF
--- a/lib/Git/Code/Review/Notify.pm
+++ b/lib/Git/Code/Review/Notify.pm
@@ -160,12 +160,12 @@ my %_DEFAULTS = (
     concerns => q{
         Greetings,
 
-        [% config.user %] has raised concerns with a commit ([% commit.sha1 %]).  You may be able to
-        assist with that concern.
+        [% config.user %] has raised concerns with a commit ([% commit.sha1 %]).
+        You may be able to assist with that concern.
 
         Reason: [% reason.short %]
 
-        [% reason.details %]
+        Details: [% reason.details %]
 
         If this was corrected please respond to this message with:
 
@@ -180,7 +180,7 @@ my %_DEFAULTS = (
 
         Reason: [% reason.short %]
 
-        [% reason.details %]
+        Details: [% reason.details %]
 
         No further action is necessary.
     },


### PR DESCRIPTION
Prefix the user-supplied comment details line by "Details:", which
should be less confusing about the actual origin of the comments.
Also reduce the width of a large line (once a full SHA1 is expanded
in it).
