### PR TITLE
Fix 'hostanme' typo

### DIFF
--- a/lib/Git/Code/Review/Utilities.pm
+++ b/lib/Git/Code/Review/Utilities.pm
@@ -689,7 +689,7 @@ sub gcr_commit_message {
     my %details = (
         context => {
             pid      => $$,
-            hostanme => hostname(),
+            hostname => hostname(),
             pwd      => getcwd,
         },
     );


### PR DESCRIPTION
Noticed with 'git log' on a review repo.
