### PR TITLE
Generate diff files with the --find-renames option

### DIFF
--- a/lib/Git/Code/Review/Command/select.pm
+++ b/lib/Git/Code/Review/Command/select.pm
@@ -159,7 +159,7 @@ sub execute {
             my $fh = IO::File->new();
             if( $fh->open($file,"w") ) {
                 # Add the content
-                print $fh "$_\n" for $source->run(show => $sha1, '-w', '--date=iso', '--pretty=fuller');
+                print $fh "$_\n" for $source->run(show => $sha1, '-w', '--date=iso', '--pretty=fuller', '--find-renames');
                 verbose("+ Added $file to the Audit.");
                 close $fh;
                 # remove the absolute path pieces


### PR DESCRIPTION
It's tedious to review commits where a file has just been moved,
with only a few lines changed. --find-renames generates a much
more concise output.