### PR TITLE
Optimise away many calls to getcwd

### DIFF
--- a/lib/Git/Code/Review/Utilities.pm
+++ b/lib/Git/Code/Review/Utilities.pm
@@ -86,7 +86,7 @@ my %CFG = (
     editor => exists $ENV{EDITOR} && exists $EDITOR{$ENV{EDITOR}} ? $ENV{EDITOR} : 'vim',
 );
 my %PATHS   = (
-    audit  => getcwd(),
+    audit  => $AUDITDIR,
     source => File::Spec->catdir($AUDITDIR,'source'),
 );
 my %ORIGINS = ();
@@ -695,7 +695,7 @@ sub gcr_commit_message {
         context => {
             pid      => $$,
             hostname => hostname(),
-            pwd      => getcwd,
+            pwd      => $AUDITDIR,
         },
     );
     my %cfg = gcr_config();


### PR DESCRIPTION
In a reasonably large audit repository, we can end up calling getcwd()
thousands of times, and this function may well be forking and exec-ing
/bin/pwd. This is slow, and we never chdir anyway, so use the global
variable initialised at startup instead.