### PR TITLE
Fixing a couple of 'uninitialized value' warnings in the report command

### DIFF
--- a/lib/Git/Code/Review/Command/report.pm
+++ b/lib/Git/Code/Review/Command/report.pm
@@ -238,7 +238,7 @@ sub execute {
 
     output({color=>'cyan'},
         '=*'x40,
-        sprintf('Git::Code::Review Report for %s through %s', $opt->{since}, $opt->{until}),
+        sprintf('Git::Code::Review Report for %s through %s', ($opt->{since} // ''), $opt->{until}),
         '=*'x40,
         '',
     );

--- a/lib/Git/Code/Review/Notify/Email.pm
+++ b/lib/Git/Code/Review/Notify/Email.pm
@@ -39,7 +39,8 @@ sub send {
     die "Message empty" unless defined $data && length $data > 0;
 
     # Set urgency
-    if($config{priority} eq 'high') {
+    my $priority = $config{priority} // '';
+    if($priority eq 'high') {
         $config{headers}->{Importance} = 'High';
         $config{headers}->{Priority}   = 'urgent';
     }
@@ -48,7 +49,7 @@ sub send {
     if( defined $data && length $data ) {
         debug("Evaluated template and received: ", $data);
         my $subject  = sprintf('%sGit::Code::Review %s %s=%s',
-            $config{priority} eq 'high' ? '[CRITICAL] ' : '',
+            $priority eq 'high' ? '[CRITICAL] ' : '',
             uc $config{name},
             (exists $config{commit} ? "COMMIT" : "REPO"),
             (exists $config{commit} ? $config{commit}->{sha1} : gcr_origin('source')),


### PR DESCRIPTION
Fixing a couple of 'uninitialized value' warnings in the report command:
Use of uninitialized value $config{"priority"} in string eq at /usr/local/booking-perl/5.18.2/site/lib/Git/Code/Review/Notify/Email.pm line 42.
Use of uninitialized value $config{"priority"} in string eq at /usr/local/booking-perl/5.18.2/site/lib/Git/Code/Review/Notify/Email.pm line 50.
Use of uninitialized value in sprintf at /usr/local/booking-perl/5.18.2/site/lib/Git/Code/Review/Command/report.pm line 239.