### PR TITLE
Adding a comment to a commit with comments shows a selection list of …

### DIFF
--- a/lib/Git/Code/Review/Command/comment.pm
+++ b/lib/Git/Code/Review/Command/comment.pm
@@ -44,7 +44,7 @@ sub execute {
         output({color=>'red'}, "Please specify a sha1 or .patch file to comment on.");
         exit 1;
     }
-    my @list = grep { !/Locked/ } $audit->run('ls-files',"*$match*");
+    my @list = grep { !/Locked/ } $audit->run('ls-files',"*$match*.patch");
     if( @list == 0 ) {
         output({color=>"red"}, "Unable to locate any unlocked files matching '$match'");
         exit 0;


### PR DESCRIPTION
…the commit and well as the comments. Trying to comment on another comment errors out with an "unknown commit object" error. This fix restricts the selection list to commits and thereby eliminates such errors.