### PR TITLE
Fixing an issue with picking up commits for review where one profile …

### DIFF
--- a/lib/Git/Code/Review/Command/pick.pm
+++ b/lib/Git/Code/Review/Command/pick.pm
@@ -169,6 +169,7 @@ sub execute {
         # Generate an ordered picklist w/o my commits and w/o my resignations
         my @picklist = sort { $a->{date} cmp $b->{date} }
                        grep { $_->{date} ge $opt->{since} && $_->{date} le $opt->{until} }
+                       grep { $_->{ profile } eq $profile }
                        map  { $_=gcr_commit_info($_) }
                        grep { /^$profile/ && gcr_not_resigned($_) && gcr_not_authored($_) }
                     $audit->run('ls-files', '*Review*');


### PR DESCRIPTION
…has the same name as the begining of another profile.

As an example consider you have two profiles: team_awesome and team_awesome_and_smart
When reviewing commits for team_awesome, the commits from team_awesome_and_smart also get picked.